### PR TITLE
Add IONOS cloud backend as DNS provider [DNS-790]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sidecars:
             name: ionos-credentials
             key: api-key
       - name: SERVER_HOST
-        value: "" 
+        value: "0.0.0.0" 
       - name: IONOS_DEBUG
         value: "true"  
 EOF

--- a/cmd/webhook/init/configuration/configuration.go
+++ b/cmd/webhook/init/configuration/configuration.go
@@ -14,7 +14,6 @@ type Config struct {
 	ExcludeDomains       []string `env:"EXCLUDE_DOMAIN_FILTER" envDefault:""`
 	RegexDomainFilter    string   `env:"REGEXP_DOMAIN_FILTER" envDefault:""`
 	RegexDomainExclusion string   `env:"REGEXP_DOMAIN_FILTER_EXCLUSION" envDefault:""`
-	DryRun               bool     `env:"DRY_RUN" envDefault:"false"`
 }
 
 // Init sets up configuration by reading set environmental variables

--- a/cmd/webhook/init/dnsprovider/dnsprovider.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider.go
@@ -21,7 +21,7 @@ const (
 	webtokenIonosISSValue = "ionoscloud"
 )
 
-type IONOSProviderFactory func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) (provider.Provider, error)
+type IONOSProviderFactory func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider
 
 func setDefaults(apiEndpointURL, authHeader string, ionosConfig *ionos.Configuration) {
 	if ionosConfig.APIEndpointURL == "" {
@@ -32,12 +32,12 @@ func setDefaults(apiEndpointURL, authHeader string, ionosConfig *ionos.Configura
 	}
 }
 
-var IonosCoreProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) (provider.Provider, error) {
+var IonosCoreProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider {
 	setDefaults("https://api.hosting.ionos.com/dns", "X-API-Key", ionosConfig)
 	return ionoscore.NewProvider(domainFilter, ionosConfig, dryRun)
 }
 
-var IonosCloudProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) (provider.Provider, error) {
+var IonosCloudProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider {
 	setDefaults("https://dns.de-fra.ionos.com", "Bearer", ionosConfig)
 	// return ionoscloud.NewProvider(domainFilter, ionosConfig, dryRun)
 	return nil, fmt.Errorf("ionos cloud DNS is not supported in this version")
@@ -58,7 +58,7 @@ func Init(config configuration.Config) (provider.Provider, error) {
 		)
 	} else {
 		if config.DomainFilter != nil && len(config.DomainFilter) > 0 {
-			createMsg += fmt.Sprintf("Domain filter: '%s', ", strings.Join(config.DomainFilter, ","))
+			createMsg += fmt.Sprintf("zoneNode filter: '%s', ", strings.Join(config.DomainFilter, ","))
 		}
 		if config.ExcludeDomains != nil && len(config.ExcludeDomains) > 0 {
 			createMsg += fmt.Sprintf("Exclude domain filter: '%s', ", strings.Join(config.ExcludeDomains, ","))
@@ -79,10 +79,7 @@ func Init(config configuration.Config) (provider.Provider, error) {
 		return nil, fmt.Errorf("reading ionos ionosConfig failed: %v", err)
 	}
 	createProvider := detectProvider(&ionosConfig)
-	provider, err := createProvider(domainFilter, &ionosConfig, config.DryRun)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize IONOS provider: %v", err)
-	}
+	provider := createProvider(domainFilter, &ionosConfig, config.DryRun)
 	return provider, nil
 }
 

--- a/cmd/webhook/init/dnsprovider/dnsprovider.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider.go
@@ -4,9 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 	"regexp"
 	"strings"
+
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 
 	"github.com/caarlos0/env/v8"
 

--- a/cmd/webhook/init/dnsprovider/dnsprovider.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider.go
@@ -23,7 +23,7 @@ const (
 	webtokenIonosISSValue = "ionoscloud"
 )
 
-type IONOSProviderFactory func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider
+type IONOSProviderFactory func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration) provider.Provider
 
 func setDefaults(apiEndpointURL, authHeader string, ionosConfig *ionos.Configuration) {
 	if ionosConfig.APIEndpointURL == "" {
@@ -34,14 +34,14 @@ func setDefaults(apiEndpointURL, authHeader string, ionosConfig *ionos.Configura
 	}
 }
 
-var IonosCoreProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider {
+var IonosCoreProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration) provider.Provider {
 	setDefaults("https://api.hosting.ionos.com/dns", "X-API-Key", ionosConfig)
-	return ionoscore.NewProvider(domainFilter, ionosConfig, dryRun)
+	return ionoscore.NewProvider(domainFilter, ionosConfig)
 }
 
-var IonosCloudProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider {
+var IonosCloudProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration) provider.Provider {
 	setDefaults("https://dns.de-fra.ionos.com", "Bearer", ionosConfig)
-	return ionoscloud.NewProvider(domainFilter, ionosConfig, dryRun)
+	return ionoscloud.NewProvider(domainFilter, ionosConfig)
 }
 
 func Init(config configuration.Config) (provider.Provider, error) {
@@ -72,15 +72,12 @@ func Init(config configuration.Config) (provider.Provider, error) {
 		createMsg += "no kind of domain filters"
 	}
 	log.Info(createMsg)
-	if config.DryRun {
-		log.Warn("***** Dry run enabled, DNS records will not be created or deleted *****")
-	}
 	ionosConfig := ionos.Configuration{}
 	if err := env.Parse(&ionosConfig); err != nil {
 		return nil, fmt.Errorf("reading ionos ionosConfig failed: %v", err)
 	}
 	createProvider := detectProvider(&ionosConfig)
-	provider := createProvider(domainFilter, &ionosConfig, config.DryRun)
+	provider := createProvider(domainFilter, &ionosConfig)
 	return provider, nil
 }
 

--- a/cmd/webhook/init/dnsprovider/dnsprovider.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 	"regexp"
 	"strings"
 
@@ -39,8 +40,7 @@ var IonosCoreProviderFactory = func(domainFilter endpoint.DomainFilter, ionosCon
 
 var IonosCloudProviderFactory = func(domainFilter endpoint.DomainFilter, ionosConfig *ionos.Configuration, dryRun bool) provider.Provider {
 	setDefaults("https://dns.de-fra.ionos.com", "Bearer", ionosConfig)
-	// return ionoscloud.NewProvider(domainFilter, ionosConfig, dryRun)
-	return nil, fmt.Errorf("ionos cloud DNS is not supported in this version")
+	return ionoscloud.NewProvider(domainFilter, ionosConfig, dryRun)
 }
 
 func Init(config configuration.Config) (provider.Provider, error) {

--- a/cmd/webhook/init/dnsprovider/dnsprovider_test.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider_test.go
@@ -1,8 +1,9 @@
 package dnsprovider
 
 import (
-	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 	"testing"
+
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 
 	"github.com/ionos-cloud/external-dns-ionos-webhook/cmd/webhook/init/configuration"
 	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscore"

--- a/cmd/webhook/init/dnsprovider/dnsprovider_test.go
+++ b/cmd/webhook/init/dnsprovider/dnsprovider_test.go
@@ -1,6 +1,7 @@
 package dnsprovider
 
 import (
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionoscloud"
 	"testing"
 
 	"github.com/ionos-cloud/external-dns-ionos-webhook/cmd/webhook/init/configuration"
@@ -31,8 +32,7 @@ func TestInit(t *testing.T) {
 			env: map[string]string{
 				"IONOS_API_KEY": "algorithm.eyAiaXNzIiA6ICJpb25vc2Nsb3VkIiB9.signature",
 			},
-			providerType:  "cloud",
-			expectedError: "failed to initialize IONOS provider: ionos cloud DNS is not supported in this version",
+			providerType: "cloud",
 		},
 		{
 			name:          "without api key you are not able to create provider",
@@ -56,11 +56,10 @@ func TestInit(t *testing.T) {
 			if tc.providerType == "core" {
 				_, ok := dnsProvider.(*ionoscore.Provider)
 				assert.True(t, ok, "provider is not of type ionoscore.Provider")
+			} else if tc.providerType == "cloud" {
+				_, ok := dnsProvider.(*ionoscloud.Provider)
+				assert.True(t, ok, "provider is not of type ionoscloud.Provider")
 			}
-			//} else if tc.providerType == "cloud" {
-			//	_, ok := dnsProvider.(*ionoscloud.Provider)
-			//	assert.True(t, ok, "provider is not of type ionoscloud.Provider")
-			//}
 		})
 	}
 }

--- a/deployments/helm/latest-ionoscore-values.yaml
+++ b/deployments/helm/latest-ionoscore-values.yaml
@@ -9,8 +9,6 @@ provider: webhook
 sources: 
   - service
 
-dryRun: true
-
 logLevel: debug
 
 extraArgs:

--- a/deployments/helm/local-kind-values.yaml
+++ b/deployments/helm/local-kind-values.yaml
@@ -9,8 +9,6 @@ provider: webhook
 sources: 
   - service
 
-dryRun: true
-
 logLevel: debug
 
 extraArgs:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/google/go-licenses v1.6.0
-	github.com/ionos-cloud/sdk-go-dns v1.1.0
+	github.com/ionos-cloud/sdk-go-dns v1.1.1
 	github.com/ionos-developer/dns-sdk-go v0.0.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/ionos-cloud/sdk-go-dns v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/google/go-licenses v1.6.0
+	github.com/ionos-cloud/sdk-go-dns v1.1.0
 	github.com/ionos-developer/dns-sdk-go v0.0.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
@@ -92,7 +93,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/ionos-cloud/sdk-go-dns v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jgautheron/goconst v1.5.1 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/ionos-cloud/sdk-go-dns v1.1.0 h1:bQCXEwNK7J+TclduWgetctQcczoNQ7DRUD6SDW/F1lU=
-github.com/ionos-cloud/sdk-go-dns v1.1.0/go.mod h1:l9gYdwtUshlBOiIi4nHn3RCX81XlV3VoNvLJrO2VfHg=
+github.com/ionos-cloud/sdk-go-dns v1.1.1 h1:Qdf5mXYt9ZeRl4zZQxGrvamFkKm1X9WeARyB9/WYhKg=
+github.com/ionos-cloud/sdk-go-dns v1.1.1/go.mod h1:l9gYdwtUshlBOiIi4nHn3RCX81XlV3VoNvLJrO2VfHg=
 github.com/ionos-developer/dns-sdk-go v0.0.5 h1:LxoAy9GoDN4zrU3xbGVEjtdGIw4BCVgYmY/ikF9aRzQ=
 github.com/ionos-developer/dns-sdk-go v0.0.5/go.mod h1:lsQ14d6pPUlTbvCL/J8hAG4V0MlzKQ+1SECGkd09tC8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/ionos-cloud/sdk-go-dns v1.1.0 h1:bQCXEwNK7J+TclduWgetctQcczoNQ7DRUD6SDW/F1lU=
+github.com/ionos-cloud/sdk-go-dns v1.1.0/go.mod h1:l9gYdwtUshlBOiIi4nHn3RCX81XlV3VoNvLJrO2VfHg=
 github.com/ionos-developer/dns-sdk-go v0.0.5 h1:LxoAy9GoDN4zrU3xbGVEjtdGIw4BCVgYmY/ikF9aRzQ=
 github.com/ionos-developer/dns-sdk-go v0.0.5/go.mod h1:lsQ14d6pPUlTbvCL/J8hAG4V0MlzKQ+1SECGkd09tC8=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/internal/ionos/configuration.go
+++ b/internal/ionos/configuration.go
@@ -6,4 +6,5 @@ type Configuration struct {
 	APIEndpointURL string `env:"IONOS_API_URL"`
 	AuthHeader     string `env:"IONOS_AUTH_HEADER"`
 	Debug          bool   `env:"IONOS_DEBUG" envDefault:"false"`
+	DryRun         bool   `env:"DRY_RUN" envDefault:"false"`
 }

--- a/internal/ionos/endpoint_helpers.go
+++ b/internal/ionos/endpoint_helpers.go
@@ -123,6 +123,7 @@ func (d *zoneNode[Z]) addZone(z Z, sub string) {
 
 func (t *ZoneTree[Z]) AddZone(zone Z, domainName string) {
 	t.root.addZone(zone, domainName)
+	t.count++
 }
 
 // FindZoneByDomainName returns the zone that matches the given domain name.
@@ -134,13 +135,19 @@ func (t *ZoneTree[Z]) FindZoneByDomainName(domainName string) Z {
 	return result
 }
 
+func (t *ZoneTree[Z]) GetZonesCount() int {
+	return t.count
+}
+
 type ZoneTree[Z any] struct {
-	root *zoneNode[Z]
+	count int
+	root  *zoneNode[Z]
 }
 
 // NewZoneTree creates a new ZoneTree.
 func NewZoneTree[Z any]() *ZoneTree[Z] {
 	return &ZoneTree[Z]{
+		count: 0,
 		root: &zoneNode[Z]{
 			children: make(map[string]*zoneNode[Z]),
 		},

--- a/internal/ionos/endpoint_helpers.go
+++ b/internal/ionos/endpoint_helpers.go
@@ -1,0 +1,154 @@
+package ionos
+
+import (
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
+	"strings"
+)
+
+func GetCreateDeleteSetsFromChanges(changes *plan.Changes) ([]*endpoint.Endpoint, []*endpoint.Endpoint) {
+	toCreate := make([]*endpoint.Endpoint, len(changes.Create))
+	copy(toCreate, changes.Create)
+
+	toDelete := make([]*endpoint.Endpoint, len(changes.Delete))
+	copy(toDelete, changes.Delete)
+
+	for i, updateOldEndpoint := range changes.UpdateOld {
+		updateNewEndpoint := changes.UpdateNew[i]
+		if endpointsAreDifferent(*updateOldEndpoint, *updateNewEndpoint) {
+			toDelete = append(toDelete, updateOldEndpoint)
+			toCreate = append(toCreate, updateNewEndpoint)
+		}
+	}
+	return toCreate, toDelete
+}
+
+func endpointsAreDifferent(a endpoint.Endpoint, b endpoint.Endpoint) bool {
+	return a.DNSName != b.DNSName || a.RecordType != b.RecordType ||
+		a.RecordTTL != b.RecordTTL || !a.Targets.Same(b.Targets)
+}
+
+type EndpointCollection struct {
+	epForAllRecords map[string]*endpoint.Endpoint
+}
+
+func NewEndpointCollection[R any](records []R, creator func(R) *endpoint.Endpoint, identifier func(R) string) *EndpointCollection {
+	epc := &EndpointCollection{
+		epForAllRecords: make(map[string]*endpoint.Endpoint, 0),
+	}
+	for _, record := range records {
+		ep := creator(record)
+		key := identifier(record)
+		if existingEp, ok := epc.epForAllRecords[key]; ok {
+			existingEp.Targets = append(existingEp.Targets, ep.Targets...)
+		} else {
+			epc.epForAllRecords[key] = ep
+		}
+	}
+	return epc
+}
+
+func (epc *EndpointCollection) RetrieveEndPoints() []*endpoint.Endpoint {
+	endpoints := make([]*endpoint.Endpoint, 0)
+	for _, ep := range epc.epForAllRecords {
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints
+}
+
+type RecordCollection[R any] struct {
+	records []R
+}
+
+func NewRecordCollection[R any](endpoints []*endpoint.Endpoint, creator func(*endpoint.Endpoint) []R) *RecordCollection[R] {
+	rc := &RecordCollection[R]{records: make([]R, 0)}
+	for _, ep := range endpoints {
+		records := creator(ep)
+		rc.records = append(rc.records, records...)
+	}
+	return rc
+}
+
+func (c *RecordCollection[R]) ForEach(visit func(R) error) error {
+	for _, record := range c.records {
+		if err := visit(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type zoneNode[Z any] struct {
+	zone     Z
+	parent   *zoneNode[Z]
+	children map[string]*zoneNode[Z]
+}
+
+func (d *zoneNode[Z]) visitZoneNodes(visitor func(*zoneNode[Z])) {
+	visitor(d)
+	for _, child := range d.children {
+		child.visitZoneNodes(visitor)
+	}
+}
+
+func (d *zoneNode[Z]) visitZoneNodesByName(name string, visitor func(*zoneNode[Z])) {
+	currentNode := d
+	nameParts := strings.Split(name, ".")
+	for i := len(nameParts) - 1; i >= 0; i-- {
+		namePart := nameParts[i]
+		if currentNode.children[namePart] == nil {
+			return
+		}
+		currentNode = currentNode.children[namePart]
+		visitor(currentNode)
+	}
+}
+
+func (d *zoneNode[Z]) addChild(zone Z, namePart string) {
+	child := &zoneNode[Z]{
+		zone:     zone,
+		parent:   d,
+		children: make(map[string]*zoneNode[Z]),
+	}
+	d.children[namePart] = child
+}
+
+func (d *zoneNode[Z]) addZone(z Z, sub string) {
+	parts := strings.Split(sub, ".")
+	lastPart := parts[len(parts)-1]
+	if d.children[lastPart] == nil {
+		if len(parts) == 1 {
+			d.addChild(z, lastPart)
+			return
+		}
+		node := &zoneNode[Z]{parent: d, children: make(map[string]*zoneNode[Z])}
+		d.children[lastPart] = node
+	}
+	d.children[lastPart].addZone(z, strings.Join(parts[:len(parts)-1], "."))
+}
+
+func (t *ZoneTree[Z]) AddZone(zone Z, domainName string) {
+	t.root.addZone(zone, domainName)
+}
+
+// FindZoneByDomainName returns the zone that matches the given domain name.
+func (t *ZoneTree[Z]) FindZoneByDomainName(domainName string) Z {
+	var result Z
+	t.root.visitZoneNodesByName(domainName, func(node *zoneNode[Z]) {
+		result = node.zone
+	})
+	return result
+}
+
+type ZoneTree[Z any] struct {
+	root *zoneNode[Z]
+}
+
+// NewZoneTree creates a new ZoneTree.
+func NewZoneTree[Z any]() *ZoneTree[Z] {
+	return &ZoneTree[Z]{
+		root: &zoneNode[Z]{
+			children: make(map[string]*zoneNode[Z]),
+		},
+	}
+}

--- a/internal/ionos/endpoint_helpers.go
+++ b/internal/ionos/endpoint_helpers.go
@@ -1,9 +1,10 @@
 package ionos
 
 import (
+	"strings"
+
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
-	"strings"
 )
 
 func GetCreateDeleteSetsFromChanges(changes *plan.Changes) ([]*endpoint.Endpoint, []*endpoint.Endpoint) {
@@ -82,13 +83,6 @@ type zoneNode[Z any] struct {
 	zone     Z
 	parent   *zoneNode[Z]
 	children map[string]*zoneNode[Z]
-}
-
-func (d *zoneNode[Z]) visitZoneNodes(visitor func(*zoneNode[Z])) {
-	visitor(d)
-	for _, child := range d.children {
-		child.visitZoneNodes(visitor)
-	}
 }
 
 func (d *zoneNode[Z]) visitZoneNodesByName(name string, visitor func(*zoneNode[Z])) {

--- a/internal/ionos/endpoint_helpers.go
+++ b/internal/ionos/endpoint_helpers.go
@@ -58,22 +58,24 @@ func (epc *EndpointCollection) RetrieveEndPoints() []*endpoint.Endpoint {
 }
 
 type RecordCollection[R any] struct {
-	records []R
+	records map[*endpoint.Endpoint][]R
 }
 
 func NewRecordCollection[R any](endpoints []*endpoint.Endpoint, creator func(*endpoint.Endpoint) []R) *RecordCollection[R] {
-	rc := &RecordCollection[R]{records: make([]R, 0)}
+	rc := &RecordCollection[R]{records: make(map[*endpoint.Endpoint][]R, 0)}
 	for _, ep := range endpoints {
 		records := creator(ep)
-		rc.records = append(rc.records, records...)
+		rc.records[ep] = records
 	}
 	return rc
 }
 
-func (c *RecordCollection[R]) ForEach(visit func(R) error) error {
-	for _, record := range c.records {
-		if err := visit(record); err != nil {
-			return err
+func (c *RecordCollection[R]) ForEach(visit func(*endpoint.Endpoint, R) error) error {
+	for ep, records := range c.records {
+		for _, record := range records {
+			if err := visit(ep, record); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/ionos/endpoint_helpers.go
+++ b/internal/ionos/endpoint_helpers.go
@@ -3,8 +3,8 @@ package ionos
 import (
 	"strings"
 
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/plan"
 )
 
 func GetCreateDeleteSetsFromChanges(changes *plan.Changes) ([]*endpoint.Endpoint, []*endpoint.Endpoint) {

--- a/internal/ionos/endpoint_helpers_test.go
+++ b/internal/ionos/endpoint_helpers_test.go
@@ -3,7 +3,7 @@ package ionos
 import (
 	"testing"
 
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/endpoint"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/ionos/endpoint_helpers_test.go
+++ b/internal/ionos/endpoint_helpers_test.go
@@ -1,7 +1,10 @@
 package ionos
 
 import (
+	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/endpoint"
 	"github.com/stretchr/testify/require"
@@ -31,18 +34,19 @@ func TestRetrieveRecords(t *testing.T) {
 		})
 	endPoints := eps.RetrieveEndPoints()
 	require.EqualValues(t, 2, len(endPoints))
-	require.EqualValues(t, &endpoint.Endpoint{
-		DNSName:    "a.com",
-		RecordType: "A",
-		Targets:    []string{"content1-a.com", "content2-a.com"},
-		RecordTTL:  300,
-	}, endPoints[0])
-	require.EqualValues(t, &endpoint.Endpoint{
-		DNSName:    "b.com",
-		RecordType: "A",
-		Targets:    []string{"content-b.com"},
-		RecordTTL:  300,
-	}, endPoints[1])
+	sort.Slice(endPoints, func(i, j int) bool {
+		return endPoints[i].DNSName < endPoints[j].DNSName
+	})
+	require.EqualValues(t, endPoints[0].DNSName, "a.com")
+	require.EqualValues(t, endPoints[0].RecordType, "A")
+	require.EqualValues(t, endPoints[0].RecordTTL, 300)
+	assert.Contains(t, endPoints[0].Targets, "content1-a.com")
+	assert.Contains(t, endPoints[0].Targets, "content2-a.com")
+
+	require.EqualValues(t, endPoints[1].DNSName, "b.com")
+	require.EqualValues(t, endPoints[1].RecordType, "A")
+	require.EqualValues(t, endPoints[1].RecordTTL, 300)
+	assert.Contains(t, endPoints[1].Targets, "content-b.com")
 }
 
 type myZone struct {

--- a/internal/ionos/endpoint_helpers_test.go
+++ b/internal/ionos/endpoint_helpers_test.go
@@ -1,9 +1,10 @@
 package ionos
 
 import (
+	"testing"
+
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type myRecord struct {
@@ -42,21 +43,19 @@ func TestRetrieveRecords(t *testing.T) {
 		Targets:    []string{"content-b.com"},
 		RecordTTL:  300,
 	}, endPoints[1])
-
 }
 
 type myZone struct {
-	id   string
 	name string
 }
 
 func TestFindZoneByName(t *testing.T) {
 	myZones := []*myZone{
-		{"1", "a.com"},
-		{"2", "a1.a.com"},
-		{"3", "a2.a.com"},
-		{"4", "b.com"},
-		{"5", "org"},
+		{"a.com"},
+		{"a1.a.com"},
+		{"a2.a.com"},
+		{"b.com"},
+		{"org"},
 	}
 	zt := NewZoneTree[*myZone]()
 
@@ -87,5 +86,4 @@ func TestFindZoneByName(t *testing.T) {
 
 	require.Nil(t, zt.FindZoneByDomainName("com"))
 	require.Nil(t, zt.FindZoneByDomainName("com.a"))
-
 }

--- a/internal/ionos/endpoint_helpers_test.go
+++ b/internal/ionos/endpoint_helpers_test.go
@@ -13,20 +13,20 @@ type myRecord struct {
 }
 
 func TestRetrieveRecords(t *testing.T) {
-	myRecords := []*myRecord{
+	myRecords := []myRecord{
 		{"a.com", "content1-a.com"},
 		{"a.com", "content2-a.com"},
 		{"b.com", "content-b.com"},
 	}
-	eps := NewEndpointCollection[*myRecord](myRecords,
-		func(record *myRecord) *endpoint.Endpoint {
+	eps := NewEndpointCollection[myRecord](myRecords,
+		func(record myRecord) *endpoint.Endpoint {
 			return &endpoint.Endpoint{
 				DNSName:    record.name,
 				RecordType: "A",
 				Targets:    []string{record.content},
 				RecordTTL:  300,
 			}
-		}, func(record *myRecord) string {
+		}, func(record myRecord) string {
 			return record.name
 		})
 	endPoints := eps.RetrieveEndPoints()

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -177,15 +177,14 @@ func createClient(ionosConfig *ionos.Configuration) *sdk.APIClient {
 		return ""
 	}
 	log.Infof(
-		"Creating ionos core DNS client with parameters: API Endpoint URL: '%v', Auth header: '%v', Debug: '%v'",
+		"Creating ionos cloud DNS client with parameters: API Endpoint URL: '%v', Auth header: '%v', Debug: '%v'",
 		ionosConfig.APIEndpointURL,
 		ionosConfig.AuthHeader,
 		ionosConfig.Debug,
 	)
 	log.Debugf("JWT: %s", jwtString())
 
-	sdkConfig := sdk.NewConfiguration("", "", "", ionosConfig.APIEndpointURL)
-	sdkConfig.AddDefaultHeader(ionosConfig.AuthHeader, ionosConfig.APIKey)
+	sdkConfig := sdk.NewConfiguration("", "", ionosConfig.APIKey, ionosConfig.APIEndpointURL)
 	sdkConfig.Debug = ionosConfig.Debug
 	apiClient := sdk.NewAPIClient(sdkConfig)
 	return apiClient

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -140,10 +140,10 @@ type Provider struct {
 }
 
 // NewProvider returns an instance of new provider
-func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration, dryRun bool) *Provider {
+func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration) *Provider {
 	client := createClient(configuration)
 	prov := &Provider{
-		client:       &DNSClient{client: client, dryRun: dryRun},
+		client:       &DNSClient{client: client, dryRun: configuration.DryRun},
 		domainFilter: domainFilter,
 	}
 	return prov
@@ -166,6 +166,10 @@ func createClient(ionosConfig *ionos.Configuration) *sdk.APIClient {
 		ionosConfig.Debug,
 	)
 	log.Debugf("JWT: %s", jwtString())
+
+	if ionosConfig.DryRun {
+		log.Warnf("*** Dry run is enabled, no changes will be made to ionos cloud DNS ***")
+	}
 
 	sdkConfig := sdk.NewConfiguration("", "", ionosConfig.APIKey, ionosConfig.APIEndpointURL)
 	sdkConfig.Debug = ionosConfig.Debug

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -45,7 +45,7 @@ type DNSService interface {
 // GetAllRecords retrieve all records https://github.com/ionos-cloud/sdk-go-dns/blob/master/docs/api/RecordsApi.md#recordsget
 func (c *DNSClient) GetAllRecords(ctx context.Context, offset int32) (sdk.RecordReadList, error) {
 	log.Debugf("get all records with offset %d ...", offset)
-	records, _, err := c.client.RecordsApi.RecordsGet(ctx).Limit(recordReadLimit).Offset(offset).Execute()
+	records, _, err := c.client.RecordsApi.RecordsGet(ctx).Limit(recordReadLimit).Offset(offset).FilterState(sdk.AVAILABLE).Execute()
 	if err != nil {
 		log.Errorf("failed to get all records: %v", err)
 		return records, err
@@ -78,7 +78,7 @@ func (c *DNSClient) GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name 
 // GetZones client get zones method
 func (c *DNSClient) GetZones(ctx context.Context, offset int32) (sdk.ZoneReadList, error) {
 	log.Debug("get all zones ...")
-	zones, _, err := c.client.ZonesApi.ZonesGet(ctx).Offset(offset).Limit(zoneReadLimit).Execute()
+	zones, _, err := c.client.ZonesApi.ZonesGet(ctx).Offset(offset).Limit(zoneReadLimit).FilterState(sdk.AVAILABLE).Execute()
 	if err != nil {
 		log.Errorf("failed to get all zones: %v", err)
 		return zones, err

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -36,10 +36,8 @@ type DNSClient struct {
 
 type DNSService interface {
 	GetAllRecords(ctx context.Context, offset int32) (sdk.RecordReadList, error)
-	GetZoneRecords(ctx context.Context, zoneId string) (sdk.RecordReadList, error)
 	GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name string) (sdk.RecordReadList, error)
 	GetZones(ctx context.Context, offset int32) (sdk.ZoneReadList, error)
-	GetZone(ctx context.Context, zoneId string) (sdk.ZoneRead, error)
 	DeleteRecord(ctx context.Context, zoneId string, recordId string) error
 	CreateRecord(ctx context.Context, zoneId string, record sdk.RecordCreate) error
 }
@@ -58,23 +56,6 @@ func (c *DNSClient) GetAllRecords(ctx context.Context, offset int32) (sdk.Record
 		log.Debug("no records found")
 	}
 	return records, err
-}
-
-// GetZoneRecords retrieve all records from zone
-func (c *DNSClient) GetZoneRecords(ctx context.Context, zoneId string) (sdk.RecordReadList, error) {
-	logger := log.WithField(logFieldZoneID, zoneId)
-	logger.Debug("get records from zone")
-	records, _, err := c.client.RecordsApi.ZonesRecordsGet(ctx, zoneId).Execute()
-	if err != nil {
-		logger.Errorf("failed to get records from zone: %v", err)
-		return records, err
-	}
-	if records.HasItems() {
-		logger.Debugf("found %d records", len(*records.Items))
-	} else {
-		logger.Debug("no records found")
-	}
-	return records, nil
 }
 
 func (c *DNSClient) GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name string) (sdk.RecordReadList, error) {
@@ -108,19 +89,6 @@ func (c *DNSClient) GetZones(ctx context.Context, offset int32) (sdk.ZoneReadLis
 		log.Debug("no zones found")
 	}
 	return zones, err
-}
-
-// GetZone client get zone method
-func (c *DNSClient) GetZone(ctx context.Context, zoneId string) (sdk.ZoneRead, error) {
-	logger := log.WithField(logFieldZoneID, zoneId)
-	logger.Debugf("find zone by id: '%s' ...", zoneId)
-	zone, _, err := c.client.ZonesApi.ZonesFindById(ctx, zoneId).Execute()
-	if err != nil {
-		logger.Errorf("failed to find zone: %v", err)
-		return zone, err
-	}
-	logger.Debugf("zone found: %v", zone)
-	return zone, err
 }
 
 // CreateRecord client create record method

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ionos-cloud/external-dns-ionos-plugin/internal/ionos"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/provider"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionos"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/plan"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/provider"
 	sdk "github.com/ionos-cloud/sdk-go-dns"
 	log "github.com/sirupsen/logrus"
 )

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -1,0 +1,383 @@
+package ionoscloud
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/internal/ionos"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/provider"
+	sdk "github.com/ionos-cloud/sdk-go-dns"
+	log "github.com/sirupsen/logrus"
+	"strconv"
+	"strings"
+)
+
+const (
+	logFieldZoneID     = "zoneID"
+	logFieldRecordID   = "recordID"
+	logFieldRecordName = "recordName"
+)
+
+type DNSClient struct {
+	client *sdk.APIClient
+	dryRun bool
+}
+
+type DNSService interface {
+	GetAllRecords(ctx context.Context) (sdk.RecordReadList, error)
+	GetZoneRecords(ctx context.Context, zoneId string) (sdk.RecordReadList, error)
+	GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name string) (sdk.RecordReadList, error)
+	GetZones(ctx context.Context) (sdk.ZoneReadList, error)
+	GetZone(ctx context.Context, zoneId string) (sdk.ZoneRead, error)
+	DeleteRecord(ctx context.Context, zoneId string, recordId string) error
+	CreateRecord(ctx context.Context, zoneId string, record sdk.RecordCreate) error
+}
+
+// GetAllRecords retrieve all records https://github.com/ionos-cloud/sdk-go-dns/blob/master/docs/api/RecordsApi.md#recordsget
+func (c *DNSClient) GetAllRecords(ctx context.Context) (sdk.RecordReadList, error) {
+	log.Debug("get all records ...")
+	records, _, err := c.client.RecordsApi.RecordsGet(ctx).Execute()
+	if err != nil {
+		log.Errorf("failed to get all records: %v", err)
+		return records, err
+	}
+	if records.HasItems() {
+		log.Debugf("found %d records", len(*records.Items))
+	} else {
+		log.Debug("no records found")
+	}
+	return records, err
+}
+
+// GetZoneRecords retrieve all records from zone
+func (c *DNSClient) GetZoneRecords(ctx context.Context, zoneId string) (sdk.RecordReadList, error) {
+	logger := log.WithField(logFieldZoneID, zoneId)
+	logger.Debug("get records from zone")
+	records, _, err := c.client.RecordsApi.ZonesRecordsGet(ctx, zoneId).Execute()
+	if err != nil {
+		logger.Errorf("failed to get records from zone: %v", err)
+		return records, err
+	}
+	if records.HasItems() {
+		logger.Debugf("found %d records", len(*records.Items))
+	} else {
+		logger.Debug("no records found")
+	}
+	return records, nil
+}
+
+func (c *DNSClient) GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name string) (sdk.RecordReadList, error) {
+	logger := log.WithField(logFieldZoneID, zoneId).WithField(logFieldRecordName, name)
+	logger.Debug("get records from zone by name ...")
+	records, _, err := c.client.RecordsApi.RecordsGet(ctx).FilterZoneId(zoneId).FilterName(name).
+		FilterState(sdk.AVAILABLE).Execute()
+	if err != nil {
+		logger.Errorf("failed to get records from zone by name: %v", err)
+		return records, err
+	}
+	if records.HasItems() {
+		logger.Debugf("found %d records", len(*records.Items))
+	} else {
+		logger.Debug("no records found")
+	}
+	return records, nil
+}
+
+// GetZones client get zones method
+func (c *DNSClient) GetZones(ctx context.Context) (sdk.ZoneReadList, error) {
+	log.Debug("get all zones ...")
+	zones, _, err := c.client.ZonesApi.ZonesGet(ctx).Execute()
+	if err != nil {
+		log.Errorf("failed to get all zones: %v", err)
+		return zones, err
+	}
+	if zones.HasItems() {
+		log.Debugf("found %d zones", len(*zones.Items))
+	} else {
+		log.Debug("no zones found")
+	}
+	return zones, err
+}
+
+// GetZone client get zone method
+func (c *DNSClient) GetZone(ctx context.Context, zoneId string) (sdk.ZoneRead, error) {
+	logger := log.WithField(logFieldZoneID, zoneId)
+	logger.Debugf("find zone by id: '%s' ...", zoneId)
+	zone, _, err := c.client.ZonesApi.ZonesFindById(ctx, zoneId).Execute()
+	if err != nil {
+		logger.Errorf("failed to find zone: %v", err)
+		return zone, err
+	}
+	logger.Debugf("zone found: %v", zone)
+	return zone, err
+}
+
+// CreateRecord client create record method
+func (c *DNSClient) CreateRecord(ctx context.Context, zoneId string, record sdk.RecordCreate) error {
+	logger := log.WithField(logFieldZoneID, zoneId).WithField(logFieldRecordName, record.GetProperties().GetName())
+	logger.Debugf("creating record: %v ...", record)
+	if !c.dryRun {
+		_, _, err := c.client.RecordsApi.ZonesRecordsPost(ctx, zoneId).RecordCreate(record).Execute()
+		if err != nil {
+			logger.Errorf("failed to create record: %v", err)
+			return err
+		}
+		logger.Debugf("record created successfully")
+	} else {
+		logger.Debugf("** DRY RUN **, record not created")
+	}
+	return nil
+}
+
+// DeleteRecord client delete record method
+func (c *DNSClient) DeleteRecord(ctx context.Context, zoneId string, recordId string) error {
+	logger := log.WithField(logFieldZoneID, zoneId).WithField(logFieldRecordID, recordId)
+	logger.Debugf("deleting record: %v ...", recordId)
+	if !c.dryRun {
+		_, err := c.client.RecordsApi.ZonesRecordsDelete(ctx, zoneId, recordId).Execute()
+		if err != nil {
+			logger.Errorf("failed to delete record: %v", err)
+			return err
+		}
+		logger.Debugf("record deleted successfully")
+	} else {
+		logger.Debugf("** DRY RUN **, record not deleted")
+	}
+	return nil
+}
+
+// Provider extends base provider to work with paas dns rest API
+type Provider struct {
+	provider.BaseProvider
+	client       DNSService
+	domainFilter endpoint.DomainFilter
+}
+
+// NewProvider returns an instance of new provider
+func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration, dryRun bool) *Provider {
+	client := createClient(configuration)
+	prov := &Provider{
+		client:       &DNSClient{client: client, dryRun: dryRun},
+		domainFilter: domainFilter,
+	}
+	return prov
+}
+
+func createClient(ionosConfig *ionos.Configuration) *sdk.APIClient {
+	jwtString := func() string {
+		split := strings.Split(ionosConfig.APIKey, ".")
+		if len(split) == 3 {
+			headerBytes, _ := base64.RawStdEncoding.DecodeString(split[0])
+			payloadBytes, _ := base64.RawStdEncoding.DecodeString(split[1])
+			return fmt.Sprintf("JWT-header: %s, JWT-payload: %s", headerBytes, payloadBytes)
+		}
+		return ""
+	}
+	log.Infof(
+		"Creating ionos core DNS client with parameters: API Endpoint URL: '%v', Auth header: '%v', Debug: '%v'",
+		ionosConfig.APIEndpointURL,
+		ionosConfig.AuthHeader,
+		ionosConfig.Debug,
+	)
+	log.Debugf("JWT: %s", jwtString())
+
+	sdkConfig := sdk.NewConfiguration("", "", "", ionosConfig.APIEndpointURL)
+	sdkConfig.AddDefaultHeader(ionosConfig.AuthHeader, ionosConfig.APIKey)
+	sdkConfig.Debug = ionosConfig.Debug
+	apiClient := sdk.NewAPIClient(sdkConfig)
+	return apiClient
+}
+
+func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+	allRecordReadList, err := p.client.GetAllRecords(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !allRecordReadList.HasItems() {
+		return []*endpoint.Endpoint{}, nil
+	}
+
+	epCollection := ionos.NewEndpointCollection[sdk.RecordRead](*allRecordReadList.GetItems(),
+		func(recordRead sdk.RecordRead) *endpoint.Endpoint {
+			record := *recordRead.GetProperties()
+			return endpoint.NewEndpointWithTTL(*record.GetName(), *record.GetType(), endpoint.TTL(*record.GetTtl()), *record.GetContent())
+		}, func(recordRead sdk.RecordRead) string {
+			record := *recordRead.GetProperties()
+			return *record.GetName() + "/" + *record.GetType() + "/" + strconv.Itoa(int(*record.GetTtl()))
+		})
+	return epCollection.RetrieveEndPoints(), nil
+}
+
+func (p *Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+	epToCreate, epToDelete := ionos.GetCreateDeleteSetsFromChanges(changes)
+	zt, err := p.createZoneTree(ctx)
+	if err != nil {
+		return err
+	}
+	recordsToDelete := ionos.NewRecordCollection[sdk.RecordRead](epToDelete, func(ep *endpoint.Endpoint) []sdk.RecordRead {
+		logger := log.WithField(logFieldRecordName, ep.DNSName)
+		records := make([]sdk.RecordRead, 0)
+		zone := zt.FindZoneByDomainName(ep.DNSName)
+		if zone.Id == nil {
+			logger.Error("no zone found for record")
+			return records
+		}
+		logger = logger.WithField(logFieldZoneID, *zone.GetId())
+		zoneRecordReadList, err := p.client.GetRecordsByZoneIdAndName(ctx, *zone.GetId(), ep.DNSName)
+		if err != nil {
+			logger.Errorf("failed to get records for zone, error: %v", err)
+			return records
+		}
+		if !zoneRecordReadList.HasItems() {
+			logger.Warn("no records found to delete for zone")
+			return records
+		}
+		result := make([]sdk.RecordRead, 0)
+		for _, recordRead := range *zoneRecordReadList.GetItems() {
+			record := *recordRead.GetProperties()
+			if *record.GetType() == ep.RecordType {
+				for _, target := range ep.Targets {
+					if *record.GetContent() == target {
+						result = append(result, recordRead)
+					}
+				}
+			}
+		}
+		if len(result) == 0 {
+			logger.Warnf("no records in zone fit to delete for endpoint: %v", ep)
+		}
+		return result
+	})
+
+	if err := recordsToDelete.ForEach(func(recordRead sdk.RecordRead) error {
+		domainName := *recordRead.GetProperties().GetName()
+		zone := zt.FindZoneByDomainName(domainName)
+		err := p.client.DeleteRecord(ctx, *zone.GetId(), *recordRead.GetId())
+		return err
+	}); err != nil {
+		return err
+	}
+
+	recordsToCreate := ionos.NewRecordCollection[*sdk.RecordCreate](epToCreate, func(ep *endpoint.Endpoint) []*sdk.RecordCreate {
+		zone := zt.FindZoneByDomainName(ep.DNSName)
+		if zone.Id == nil {
+			return nil
+		}
+		result := make([]*sdk.RecordCreate, 0)
+		for _, target := range ep.Targets {
+			record := sdk.NewRecord(ep.DNSName, ep.RecordType, target)
+			ttl := int32(ep.RecordTTL)
+			if ttl != 0 {
+				record.SetTtl(ttl)
+			}
+			result = append(result, sdk.NewRecordCreate(*record))
+		}
+		return result
+	})
+	if err := recordsToCreate.ForEach(func(recordCreate *sdk.RecordCreate) error {
+		domainName := *recordCreate.GetProperties().GetName()
+		zone := zt.FindZoneByDomainName(domainName)
+		err := p.client.CreateRecord(ctx, *zone.GetId(), *recordCreate)
+		return err
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+//func endpointFitRecord(ep *endpoint.Endpoint, record *sdk.Record) bool {
+//	if *record.GetName() == ep.DNSName &&
+//		*record.GetType() == ep.RecordType {
+//		for _, target := range ep.Targets {
+//			if *record.GetContent() == target {
+//				return true
+//			}
+//		}
+//	}
+//	return false
+//}
+//
+//func (p *Provider) createEndpoint(ctx context.Context, ep *endpoint.Endpoint, zt *ionos.ZoneTree) error {
+//	zoneId := zt.FindZoneByDomainName(ep.DNSName)
+//	records := ionos.EndpointToRecords(ep, func(name, t, content string, ttl int64) *sdk.Record {
+//		record := sdk.NewRecord(name, t, content)
+//		if ttl > 0 {
+//			record.SetTtl(int32(ttl))
+//		}
+//		return record
+//	})
+//	for _, record := range records {
+//		err := p.client.CreateRecord(ctx, zoneId, *sdk.NewRecordCreate(*record))
+//		if err != nil {
+//			return err
+//		}
+//	}
+//	return nil
+//}
+//
+//func (p *Provider) recordsOfEndpoint(ctx context.Context, e *endpoint.Endpoint, zt *ionos.ZoneTree) (*sdk.RecordReadList, error) {
+//	zoneId := zt.FindZoneByDomainName(e.DNSName)
+//	zoneRead, err := p.client.GetZone(ctx, zoneId)
+//	if err != nil {
+//		return nil, err
+//	}
+//	allrecords, err := p.client.GetZoneRecords(ctx, *zoneRead.GetId())
+//	if err != nil {
+//		return nil, err
+//	}
+//	return &allrecords, nil
+//}
+//
+//func (p *Provider) deleteEndpoint(ctx context.Context, e *endpoint.Endpoint, zt *ionos.ZoneTree[*sdk.ZoneRead]) error {
+//	zoneRead := zt.FindZoneByDomainName(e.DNSName)
+//	if zoneRead == nil {
+//		return fmt.Errorf("no zone for endpoint name '%s' found", e.DNSName)
+//	}
+//	records, err := p.client.GetZoneRecords(ctx, *zoneRead.GetId())
+//	if err != nil {
+//		return err
+//	}
+//	for _, recordRead := range *records.GetItems() {
+//		record := recordRead.GetProperties()
+//		if endpointFitRecord(e, record) {
+//			err := p.client.DeleteRecord(ctx, *zoneRead.GetId(), *recordRead.GetId())
+//			if err != nil {
+//				return err
+//			}
+//		} else {
+//			log.Warnf("no records from zone '%s'(id: '%s') matched endpoint: %v", *zoneRead.GetProperties().GetZoneName(), *zoneRead.GetId(), e)
+//		}
+//	}
+//	return nil
+//}
+
+func (p *Provider) createZoneTree(ctx context.Context) (*ionos.ZoneTree[sdk.ZoneRead], error) {
+	zt := ionos.NewZoneTree[sdk.ZoneRead]()
+	zoneReadList, err := p.client.GetZones(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if zoneReadList.HasItems() {
+		for _, zoneRead := range *zoneReadList.GetItems() {
+			zt.AddZone(zoneRead, *zoneRead.GetProperties().GetZoneName())
+		}
+	}
+	return zt, nil
+}
+
+//func checkZone(zone *sdk.ZoneRead) error {
+//	if zone.HasId() && zone.HasProperties() && zone.GetProperties().HasZoneName() {
+//		return nil
+//	}
+//	return fmt.Errorf("zone has no id, or name")
+//}
+//
+//func checkRecord(record *sdk.RecordRead) error {
+//	if record.HasId() && record.HasProperties() &&
+//		record.GetProperties().HasName() && record.GetProperties().HasType() {
+//		return nil
+//	}
+//	return fmt.Errorf("record has no id, or name")
+//}

--- a/internal/ionoscloud/ionoscloud.go
+++ b/internal/ionoscloud/ionoscloud.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/ionos-cloud/external-dns-ionos-plugin/internal/ionos"
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
 	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/provider"
 	sdk "github.com/ionos-cloud/sdk-go-dns"
 	log "github.com/sirupsen/logrus"
-	"strconv"
-	"strings"
 )
 
 const (

--- a/internal/ionoscloud/ionoscloud_test.go
+++ b/internal/ionoscloud/ionoscloud_test.go
@@ -6,9 +6,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ionos-cloud/external-dns-ionos-plugin/internal/ionos"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
-	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/internal/ionos"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-webhook/pkg/plan"
 	sdk "github.com/ionos-cloud/sdk-go-dns"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/internal/ionoscloud/ionoscloud_test.go
+++ b/internal/ionoscloud/ionoscloud_test.go
@@ -21,11 +21,11 @@ func TestNewProvider(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	t.Setenv("IONOS_API_KEY", "1")
 
-	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{}, true)
+	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{})
 	require.Equal(t, true, p.domainFilter.IsConfigured())
 	require.Equal(t, false, p.domainFilter.Match("b.de."))
 
-	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{}, false)
+	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{})
 	require.Equal(t, false, p.domainFilter.IsConfigured())
 	require.Equal(t, true, p.domainFilter.Match("a.de."))
 }

--- a/internal/ionoscloud/ionoscloud_test.go
+++ b/internal/ionoscloud/ionoscloud_test.go
@@ -1,0 +1,572 @@
+package ionoscloud
+
+import (
+	"context"
+	"fmt"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/internal/ionos"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/endpoint"
+	"github.com/ionos-cloud/external-dns-ionos-plugin/pkg/plan"
+	sdk "github.com/ionos-cloud/sdk-go-dns"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func createRecordReadList(count int, modifier func(int) (string, string, int32, string)) sdk.RecordReadList {
+	records := make([]sdk.RecordRead, count)
+	for i := 0; i < count; i++ {
+		name, typ, ttl, content := modifier(i)
+		records[i] = sdk.RecordRead{
+			Id: sdk.PtrString(fmt.Sprintf("%d", i+1)),
+			Properties: &sdk.Record{
+				Name:    sdk.PtrString(name),
+				Type:    sdk.PtrString(typ),
+				Ttl:     sdk.PtrInt32(ttl),
+				Content: sdk.PtrString(content),
+			},
+		}
+	}
+	return sdk.RecordReadList{Items: &records}
+}
+
+//func createRecordReadList(count int, name, typ string) sdk.RecordReadList {
+//	records := make([]sdk.RecordRead, count)
+//	for i := 0; i < count; i++ {
+//		n := strconv.Itoa(i + 1)
+//		records[i] = sdk.RecordRead{
+//			Id: sdk.PtrString(fmt.Sprintf("%d", i)),
+//			Properties: &sdk.Record{
+//				Name:    sdk.PtrString("a" + n + "." + name),
+//				Type:    sdk.PtrString(typ),
+//				Ttl:     sdk.PtrInt32(int32((i + 1) * 100)),
+//				Content: sdk.PtrString(n + "." + n + "." + n + "." + n),
+//			},
+//		}
+//	}
+//	return sdk.RecordReadList{Items: &records}
+//}
+
+func TestNewProvider(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	t.Setenv("IONOS_API_KEY", "1")
+
+	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{}, true)
+	require.Equal(t, true, p.domainFilter.IsConfigured())
+	require.Equal(t, false, p.domainFilter.Match("b.de."))
+
+	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{}, false)
+	require.Equal(t, false, p.domainFilter.IsConfigured())
+	require.Equal(t, true, p.domainFilter.Match("a.de."))
+}
+
+func TestRecords(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	ctx := context.Background()
+	testCases := []struct {
+		name              string
+		givenRecords      sdk.RecordReadList
+		givenError        error
+		expectedEndpoints []*endpoint.Endpoint
+		expectedError     error
+	}{
+		{
+			name:              "no records",
+			givenRecords:      sdk.RecordReadList{},
+			expectedEndpoints: []*endpoint.Endpoint{},
+		},
+		{
+			name: "multiple A records",
+			givenRecords: createRecordReadList(3, func(i int) (string, string, int32, string) {
+				return "a" + fmt.Sprintf("%d", i+1) + ".a.de", "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+			}),
+			expectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "a1.a.de",
+					RecordType: "A",
+					Targets:    []string{"1.1.1.1"},
+					RecordTTL:  100,
+					Labels:     map[string]string{},
+				},
+				{
+					DNSName:    "a2.a.de",
+					RecordType: "A",
+					Targets:    []string{"2.2.2.2"},
+					RecordTTL:  200,
+					Labels:     map[string]string{},
+				},
+				{
+					DNSName:    "a3.a.de",
+					RecordType: "A",
+					Targets:    []string{"3.3.3.3"},
+					RecordTTL:  300,
+					Labels:     map[string]string{},
+				},
+			},
+		},
+		{
+			name: "records mapped to same endpoint",
+			givenRecords: sdk.RecordReadList{
+				Items: &[]sdk.RecordRead{
+					{
+						Id: sdk.PtrString("1"),
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("a.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("1.1.1.1"),
+						},
+					},
+					{
+						Id: sdk.PtrString("2"),
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("a.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("2.2.2.2"),
+						},
+					},
+					{
+						Id: sdk.PtrString("3"),
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("c.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("3.3.3.3"),
+						},
+					},
+				},
+			},
+			expectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "a.de",
+					RecordType: "A",
+					Targets:    []string{"1.1.1.1", "2.2.2.2"},
+					RecordTTL:  300,
+					Labels:     map[string]string{},
+				},
+				{
+					DNSName:    "c.de",
+					RecordType: "A",
+					Targets:    []string{"3.3.3.3"},
+					RecordTTL:  300,
+					Labels:     map[string]string{},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDnsClient := &mockDNSClient{
+				allRecords:  tc.givenRecords,
+				returnError: tc.givenError,
+			}
+			provider := &Provider{client: mockDnsClient}
+			endpoints, err := provider.Records(ctx)
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, endpoints, len(tc.expectedEndpoints))
+			assert.ElementsMatch(t, tc.expectedEndpoints, endpoints)
+		})
+	}
+
+	mockDnsClient := &mockDNSClient{
+		allRecords: *sdk.NewRecordReadListWithDefaults(),
+	}
+
+	provider := &Provider{client: mockDnsClient}
+	endpoints, err := provider.Records(ctx)
+	require.NoError(t, err)
+	require.Len(t, endpoints, 0)
+}
+
+func TestApplyChanges(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	log.SetReportCaller(true)
+	deZoneId := "deZoneId"
+	comZoneId := "comZoneId"
+	ctx := context.Background()
+	testCases := []struct {
+		name                   string
+		givenRecords           sdk.RecordReadList
+		givenZones             sdk.ZoneReadList
+		givenZoneRecords       map[string]*sdk.RecordReadList
+		givenError             error
+		whenChanges            *plan.Changes
+		expectedError          error
+		expectedRecordsCreated map[string][]sdk.RecordCreate
+		expectedRecordsDeleted map[string][]string
+	}{
+		{
+			name:                   "no changes",
+			givenZones:             sdk.ZoneReadList{},
+			givenZoneRecords:       map[string]*sdk.RecordReadList{},
+			whenChanges:            &plan.Changes{},
+			expectedRecordsCreated: nil,
+			expectedRecordsDeleted: nil,
+		},
+		{
+			name: "create one record in a blank zone",
+			givenZones: sdk.ZoneReadList{
+				Items: &[]sdk.ZoneRead{
+					{
+						Id: sdk.PtrString(deZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("de"),
+						},
+					},
+				},
+			},
+			givenZoneRecords: map[string]*sdk.RecordReadList{
+				deZoneId: {
+					Items: &[]sdk.RecordRead{},
+				},
+			},
+			whenChanges: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "a.de",
+						RecordType: "A",
+						Targets:    []string{"1.2.3.4"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+				},
+			},
+			expectedRecordsCreated: map[string][]sdk.RecordCreate{
+				deZoneId: {
+					{
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("a.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("1.2.3.4"),
+							Enabled: sdk.PtrBool(true),
+						},
+					},
+				},
+			},
+			expectedRecordsDeleted: nil,
+		},
+		{
+			name: "create 2 records from one endpoint in a blank zone",
+			givenZones: sdk.ZoneReadList{
+				Items: &[]sdk.ZoneRead{
+					{
+						Id: sdk.PtrString(deZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("de"),
+						},
+					},
+				},
+			},
+			givenZoneRecords: map[string]*sdk.RecordReadList{
+				deZoneId: {
+					Items: &[]sdk.RecordRead{},
+				},
+			},
+			whenChanges: &plan.Changes{
+				Create: []*endpoint.Endpoint{
+					{
+						DNSName:    "a.de",
+						RecordType: "A",
+						Targets:    []string{"1.2.3.4", "5.6.7.8"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+				},
+			},
+			expectedRecordsCreated: map[string][]sdk.RecordCreate{
+				deZoneId: {
+					{
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("a.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("1.2.3.4"),
+							Enabled: sdk.PtrBool(true),
+						},
+					},
+					{
+						Properties: &sdk.Record{
+							Name:    sdk.PtrString("a.de"),
+							Type:    sdk.PtrString("A"),
+							Ttl:     sdk.PtrInt32(300),
+							Content: sdk.PtrString("5.6.7.8"),
+							Enabled: sdk.PtrBool(true),
+						},
+					},
+				},
+			},
+			expectedRecordsDeleted: nil,
+		},
+		{
+			name: "delete the only record in a zone",
+			givenZones: sdk.ZoneReadList{
+				Items: &[]sdk.ZoneRead{
+					{
+						Id: sdk.PtrString(deZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("de"),
+						},
+					},
+				},
+			},
+			givenZoneRecords: map[string]*sdk.RecordReadList{
+				deZoneId: {
+					Items: &[]sdk.RecordRead{
+						{
+							Id: sdk.PtrString("1"),
+							Properties: &sdk.Record{
+								Name:    sdk.PtrString("a.de"),
+								Type:    sdk.PtrString("A"),
+								Ttl:     sdk.PtrInt32(300),
+								Content: sdk.PtrString("1.2.3.4"),
+								Enabled: sdk.PtrBool(true),
+							},
+						},
+					},
+				},
+			},
+			whenChanges: &plan.Changes{
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "a.de",
+						RecordType: "A",
+						Targets:    []string{"1.2.3.4"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+				},
+			},
+			expectedRecordsCreated: nil,
+			expectedRecordsDeleted: map[string][]string{
+				deZoneId: {"1"},
+			},
+		},
+		{
+			name: "delete multiple records, in different zones",
+			givenZones: sdk.ZoneReadList{
+				Items: &[]sdk.ZoneRead{
+					{
+						Id: sdk.PtrString(deZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("de"),
+						},
+					},
+					{
+						Id: sdk.PtrString(comZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("com"),
+						},
+					},
+				},
+			},
+			givenZoneRecords: map[string]*sdk.RecordReadList{
+				deZoneId: {
+					Items: &[]sdk.RecordRead{
+						{
+							Id: sdk.PtrString("1"),
+							Properties: &sdk.Record{
+								Name:    sdk.PtrString("a.de"),
+								Type:    sdk.PtrString("A"),
+								Ttl:     sdk.PtrInt32(300),
+								Content: sdk.PtrString("1.2.3.4"),
+								Enabled: sdk.PtrBool(true),
+							},
+						},
+						{
+							Id: sdk.PtrString("2"),
+							Properties: &sdk.Record{
+								Name:    sdk.PtrString("a.de"),
+								Type:    sdk.PtrString("A"),
+								Ttl:     sdk.PtrInt32(300),
+								Content: sdk.PtrString("5.6.7.8"),
+								Enabled: sdk.PtrBool(true),
+							},
+						},
+					},
+				},
+				comZoneId: {
+					Items: &[]sdk.RecordRead{
+						{
+							Id: sdk.PtrString("3"),
+							Properties: &sdk.Record{
+								Name:    sdk.PtrString("a.com"),
+								Type:    sdk.PtrString("A"),
+								Ttl:     sdk.PtrInt32(300),
+								Content: sdk.PtrString("11.22.33.44"),
+								Enabled: sdk.PtrBool(true),
+							},
+						},
+					},
+				},
+			},
+			whenChanges: &plan.Changes{
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "a.de",
+						RecordType: "A",
+						Targets:    []string{"1.2.3.4", "5.6.7.8"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+					{
+						DNSName:    "a.com",
+						RecordType: "A",
+						Targets:    []string{"11.22.33.44"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+				},
+			},
+			expectedRecordsCreated: nil,
+			expectedRecordsDeleted: map[string][]string{
+				deZoneId:  {"1", "2"},
+				comZoneId: {"3"},
+			},
+		},
+		{
+			name: "delete record which is not in the zone, deletes nothing",
+			givenZones: sdk.ZoneReadList{
+				Items: &[]sdk.ZoneRead{
+					{
+						Id: sdk.PtrString(deZoneId),
+						Properties: &sdk.Zone{
+							ZoneName: sdk.PtrString("de"),
+						},
+					},
+				},
+			},
+			givenZoneRecords: map[string]*sdk.RecordReadList{
+				deZoneId: {
+					Items: &[]sdk.RecordRead{},
+				},
+			},
+			whenChanges: &plan.Changes{
+				Delete: []*endpoint.Endpoint{
+					{
+						DNSName:    "a.de",
+						RecordType: "A",
+						Targets:    []string{"1.2.3.4"},
+						RecordTTL:  300,
+						Labels:     map[string]string{},
+					},
+				},
+			},
+			expectedRecordsCreated: nil,
+			expectedRecordsDeleted: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDnsClient := &mockDNSClient{
+				allRecords:  tc.givenRecords,
+				allZones:    tc.givenZones,
+				zoneRecords: tc.givenZoneRecords,
+				returnError: tc.givenError,
+			}
+			provider := &Provider{client: mockDnsClient}
+			err := provider.ApplyChanges(ctx, tc.whenChanges)
+			if tc.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.expectedError, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, mockDnsClient.createdRecords, len(tc.expectedRecordsCreated))
+			for zoneId, expectedRecordsCreated := range tc.expectedRecordsCreated {
+				actualRecords, ok := mockDnsClient.createdRecords[zoneId]
+				require.True(t, ok)
+				for i, actualRecord := range actualRecords {
+					expJson, _ := expectedRecordsCreated[i].MarshalJSON()
+					actJson, _ := actualRecord.MarshalJSON()
+					require.Equal(t, expJson, actJson)
+				}
+			}
+			for zoneId, expectedDeletedRecordIds := range tc.expectedRecordsDeleted {
+				require.Len(t, mockDnsClient.deletedRecords[zoneId], len(expectedDeletedRecordIds), "deleted records in zone '%s' do not fit", zoneId)
+				actualDeletedRecordIds, ok := mockDnsClient.deletedRecords[zoneId]
+				require.True(t, ok)
+				assert.ElementsMatch(t, expectedDeletedRecordIds, actualDeletedRecordIds)
+			}
+		})
+	}
+
+}
+
+type mockDNSClient struct {
+	returnError    error
+	allRecords     sdk.RecordReadList
+	zoneRecords    map[string]*sdk.RecordReadList
+	allZones       sdk.ZoneReadList
+	createdRecords map[string][]sdk.RecordCreate // zoneId -> recordCreates
+	deletedRecords map[string][]string           // zoneId -> recordIds
+}
+
+func (c *mockDNSClient) GetAllRecords(ctx context.Context) (sdk.RecordReadList, error) {
+	log.Debugf("GetAllRecords called")
+	return c.allRecords, c.returnError
+}
+
+func (c *mockDNSClient) GetZoneRecords(ctx context.Context, zoneId string) (sdk.RecordReadList, error) {
+	log.Debugf("GetZoneRecords called with zoneId %s", zoneId)
+	return *c.zoneRecords[zoneId], c.returnError
+}
+
+func (c *mockDNSClient) GetRecordsByZoneIdAndName(ctx context.Context, zoneId, name string) (sdk.RecordReadList, error) {
+	log.Debugf("GetRecordsByZoneIdAndName called with zoneId %s and name %s", zoneId, name)
+	result := make([]sdk.RecordRead, 0)
+	recordsOfZone := c.zoneRecords[zoneId]
+	for _, recordRead := range *recordsOfZone.GetItems() {
+		if *recordRead.GetProperties().GetName() == name {
+			result = append(result, recordRead)
+		}
+	}
+	return sdk.RecordReadList{Items: &result}, c.returnError
+}
+
+func (c *mockDNSClient) GetZones(ctx context.Context) (sdk.ZoneReadList, error) {
+	log.Debug("GetZones called ")
+	if c.allZones.HasItems() {
+		for _, zone := range *c.allZones.GetItems() {
+			log.Debugf("GetZones: zone '%s' with id '%s'", *zone.GetProperties().GetZoneName(), *zone.GetId())
+		}
+	} else {
+		log.Debug("GetZones: no zones")
+	}
+	return c.allZones, c.returnError
+}
+
+func (c *mockDNSClient) GetZone(ctx context.Context, zoneId string) (sdk.ZoneRead, error) {
+	log.Debugf("GetZone called with zoneId '%s", zoneId)
+	for _, zone := range *c.allZones.GetItems() {
+		if *zone.GetId() == zoneId {
+			return zone, nil
+		}
+	}
+	return *sdk.NewZoneReadWithDefaults(), c.returnError
+}
+
+func (c *mockDNSClient) CreateRecord(ctx context.Context, zoneId string, record sdk.RecordCreate) error {
+	log.Debugf("CreateRecord called with zoneId %s and record %v", zoneId, record)
+	if c.createdRecords == nil {
+		c.createdRecords = make(map[string][]sdk.RecordCreate)
+	}
+	c.createdRecords[zoneId] = append(c.createdRecords[zoneId], record)
+	return c.returnError
+}
+
+func (c *mockDNSClient) DeleteRecord(ctx context.Context, zoneId string, recordId string) error {
+	log.Debugf("DeleteRecord called with zoneId %s and recordId %s", zoneId, recordId)
+	if c.deletedRecords == nil {
+		c.deletedRecords = make(map[string][]string)
+	}
+	c.deletedRecords[zoneId] = append(c.deletedRecords[zoneId], recordId)
+	return c.returnError
+}

--- a/internal/ionoscloud/ionoscloud_test.go
+++ b/internal/ionoscloud/ionoscloud_test.go
@@ -55,8 +55,10 @@ func TestRecords(t *testing.T) {
 		},
 		{
 			name: "multiple A records",
-			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, int32, string) {
-				return "a" + fmt.Sprintf("%d", i+1) + ".a.de", "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, string, int32, string) {
+				recordName := "a" + fmt.Sprintf("%d", i+1)
+				fqdn := recordName + ".a.de"
+				return recordName, fqdn, "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 			}),
 			expectedEndpoints: createEndpointSlice(3, func(i int) (string, string, endpoint.TTL, []string) {
 				return "a" + fmt.Sprintf("%d", i+1) + ".a.de", "A", endpoint.TTL((i + 1) * 100), []string{fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)}
@@ -64,11 +66,15 @@ func TestRecords(t *testing.T) {
 		},
 		{
 			name: "multiple records filtered by domain",
-			givenRecords: createRecordReadList(6, 0, func(i int) (string, string, int32, string) {
+			givenRecords: createRecordReadList(6, 0, func(i int) (string, string, string, int32, string) {
 				if i < 3 {
-					return "a" + fmt.Sprintf("%d", i+1) + ".a.de", "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+					recordName := "a" + fmt.Sprintf("%d", i+1)
+					fqdn := recordName + ".a.de"
+					return recordName, fqdn, "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 				}
-				return "b" + fmt.Sprintf("%d", i+1) + ".b.de", "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+				recordName := "b" + fmt.Sprintf("%d", i+1)
+				fqdn := recordName + ".b.de"
+				return recordName, fqdn, "A", int32((i + 1) * 100), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 			}),
 			givenDomainFilter: endpoint.NewDomainFilter([]string{"a.de"}),
 			expectedEndpoints: createEndpointSlice(3, func(i int) (string, string, endpoint.TTL, []string) {
@@ -77,11 +83,11 @@ func TestRecords(t *testing.T) {
 		},
 		{
 			name: "records mapped to same endpoint",
-			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, int32, string) {
+			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, string, int32, string) {
 				if i < 2 {
-					return "a.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+					return "", "a.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 				} else {
-					return "c.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+					return "", "c.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 				}
 			}),
 			expectedEndpoints: createEndpointSlice(2, func(i int) (string, string, endpoint.TTL, []string) {
@@ -94,11 +100,11 @@ func TestRecords(t *testing.T) {
 		},
 		{
 			name: "read multiple pages of records ",
-			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, int32, string) {
+			givenRecords: createRecordReadList(3, 0, func(i int) (string, string, string, int32, string) {
 				if i < 2 {
-					return "a.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+					return "", "a.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 				} else {
-					return "c.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
+					return "", "c.de", "A", int32(300), fmt.Sprintf("%d.%d.%d.%d", i+1, i+1, i+1, i+1)
 				}
 			}),
 			expectedEndpoints: createEndpointSlice(2, func(i int) (string, string, endpoint.TTL, []string) {
@@ -179,7 +185,7 @@ func TestApplyChanges(t *testing.T) {
 			},
 			expectedRecordsCreated: map[string][]sdk.RecordCreate{
 				deZoneId: createRecordCreateSlice(1, func(i int) (string, string, int32, string) {
-					return "a.de", "A", int32(300), "1.2.3.4"
+					return "", "A", int32(300), "1.2.3.4"
 				}),
 			},
 			expectedRecordsDeleted: nil,
@@ -217,9 +223,9 @@ func TestApplyChanges(t *testing.T) {
 			expectedRecordsCreated: map[string][]sdk.RecordCreate{
 				deZoneId: createRecordCreateSlice(2, func(i int) (string, string, int32, string) {
 					if i == 0 {
-						return "a.de", "A", int32(300), "1.2.3.4"
+						return "a", "A", int32(300), "1.2.3.4"
 					} else {
-						return "a.de", "A", int32(300), "5.6.7.8"
+						return "a", "A", int32(300), "5.6.7.8"
 					}
 				}),
 			},
@@ -231,8 +237,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", int32(300), "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", int32(300), "1.2.3.4"
 				}),
 			},
 			whenChanges: &plan.Changes{
@@ -250,8 +256,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", int32(300), "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", int32(300), "1.2.3.4"
 				}),
 			},
 			givenDomainFilter: endpoint.NewDomainFilter([]string{"b.de"}),
@@ -272,15 +278,15 @@ func TestApplyChanges(t *testing.T) {
 				}
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(2, 0, func(n int) (string, string, int32, string) {
+				deZoneId: createRecordReadList(2, 0, func(n int) (string, string, string, int32, string) {
 					if n == 0 {
-						return "a.de", "A", 300, "1.2.3.4"
+						return "a", "a.de", "A", 300, "1.2.3.4"
 					} else {
-						return "a.de", "A", 300, "5.6.7.8"
+						return "a", "a.de", "A", 300, "5.6.7.8"
 					}
 				}),
-				comZoneId: createRecordReadList(1, 2, func(n int) (string, string, int32, string) {
-					return "a.com", "A", 300, "11.22.33.44"
+				comZoneId: createRecordReadList(1, 2, func(n int) (string, string, string, int32, string) {
+					return "a", "a.com", "A", 300, "11.22.33.44"
 				}),
 			},
 			whenChanges: &plan.Changes{
@@ -318,8 +324,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", 300, "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", 300, "1.2.3.4"
 				}),
 			},
 			whenChanges: &plan.Changes{
@@ -337,8 +343,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", 300, "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", 300, "1.2.3.4"
 				}),
 			},
 			whenChanges: &plan.Changes{
@@ -354,7 +360,7 @@ func TestApplyChanges(t *testing.T) {
 			},
 			expectedRecordsCreated: map[string][]sdk.RecordCreate{
 				deZoneId: createRecordCreateSlice(1, func(i int) (string, string, int32, string) {
-					return "a.de", "A", 300, "5.6.7.8"
+					return "a", "A", 300, "5.6.7.8"
 				}),
 			},
 		},
@@ -364,8 +370,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", 300, "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", 300, "1.2.3.4"
 				}),
 			},
 			givenDomainFilter: endpoint.NewDomainFilter([]string{"b.de"}),
@@ -387,8 +393,8 @@ func TestApplyChanges(t *testing.T) {
 				return deZoneId, "de"
 			}),
 			givenZoneRecords: map[string]sdk.RecordReadList{
-				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, int32, string) {
-					return "a.de", "A", 300, "1.2.3.4"
+				deZoneId: createRecordReadList(1, 0, func(i int) (string, string, string, int32, string) {
+					return "a", "a.de", "A", 300, "1.2.3.4"
 				}),
 			},
 			whenChanges: &plan.Changes{
@@ -475,8 +481,9 @@ type pagingMockDNSService struct {
 
 func (p pagingMockDNSService) GetAllRecords(ctx context.Context, offset int32) (sdk.RecordReadList, error) {
 	require.Equal(p.t, 0, int(offset)%recordReadLimit)
-	records := createRecordReadList(recordReadLimit, int(offset), func(i int) (string, string, int32, string) {
-		return fmt.Sprintf("a%d.de", int(offset)+i), "A", 300, "1.1.1.1"
+	records := createRecordReadList(recordReadLimit, int(offset), func(i int) (string, string, string, int32, string) {
+		recordName := fmt.Sprintf("a%d", int(offset)+i)
+		return recordName, recordName + ".de", "A", 300, "1.1.1.1"
 	})
 	return records, nil
 }
@@ -621,10 +628,10 @@ func createRecordCreateSlice(count int, modifier func(int) (string, string, int3
 	return records
 }
 
-func createRecordReadList(count, idOffset int, modifier func(int) (string, string, int32, string)) sdk.RecordReadList {
+func createRecordReadList(count, idOffset int, modifier func(int) (string, string, string, int32, string)) sdk.RecordReadList {
 	records := make([]sdk.RecordRead, count)
 	for i := 0; i < count; i++ {
-		name, typ, ttl, content := modifier(i)
+		name, fqdn, typ, ttl, content := modifier(i)
 		// use random number as id
 		id := i + idOffset
 		records[i] = sdk.RecordRead{
@@ -634,6 +641,9 @@ func createRecordReadList(count, idOffset int, modifier func(int) (string, strin
 				Type:    sdk.PtrString(typ),
 				Ttl:     sdk.PtrInt32(ttl),
 				Content: sdk.PtrString(content),
+			},
+			Metadata: &sdk.MetadataWithStateFqdnZoneId{
+				Fqdn: sdk.PtrString(fqdn),
 			},
 		}
 	}

--- a/internal/ionoscore/ionoscore.go
+++ b/internal/ionoscore/ionoscore.go
@@ -63,13 +63,13 @@ func (c DnsClient) DeleteRecord(ctx context.Context, zoneId string, recordId str
 }
 
 // NewProvider creates a new IONOS DNS provider.
-func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration, dryRun bool) *Provider {
+func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration) *Provider {
 	client := createClient(configuration)
 
 	prov := &Provider{
 		client:       DnsClient{client: client},
 		domainFilter: domainFilter,
-		dryRun:       dryRun,
+		dryRun:       configuration.DryRun,
 	}
 
 	return prov
@@ -89,6 +89,9 @@ func createClient(config *ionos.Configuration) *sdk.APIClient {
 		maskAPIKey(),
 		config.Debug,
 	)
+	if config.DryRun {
+		log.Warnf("*** Dry run is enabled, no changes will be made to ionos core DNS ***")
+	}
 
 	sdkConfig := sdk.NewConfiguration()
 	if config.APIEndpointURL != "" {

--- a/internal/ionoscore/ionoscore.go
+++ b/internal/ionoscore/ionoscore.go
@@ -41,10 +41,6 @@ type DnsClient struct {
 // GetZones client get zones method
 func (c DnsClient) GetZones(ctx context.Context) ([]sdk.Zone, error) {
 	zones, _, err := c.client.ZonesApi.GetZones(ctx).Execute()
-	if err != nil {
-		return nil, err
-	}
-
 	return zones, err
 }
 
@@ -67,11 +63,8 @@ func (c DnsClient) DeleteRecord(ctx context.Context, zoneId string, recordId str
 }
 
 // NewProvider creates a new IONOS DNS provider.
-func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration, dryRun bool) (*Provider, error) {
-	client, err := createClient(configuration)
-	if err != nil {
-		return nil, fmt.Errorf("provider creation failed, %v", err)
-	}
+func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Configuration, dryRun bool) *Provider {
+	client := createClient(configuration)
 
 	prov := &Provider{
 		client:       DnsClient{client: client},
@@ -79,10 +72,10 @@ func NewProvider(domainFilter endpoint.DomainFilter, configuration *ionos.Config
 		dryRun:       dryRun,
 	}
 
-	return prov, nil
+	return prov
 }
 
-func createClient(config *ionos.Configuration) (*sdk.APIClient, error) {
+func createClient(config *ionos.Configuration) *sdk.APIClient {
 	maskAPIKey := func() string {
 		if len(config.APIKey) <= 3 {
 			return strings.Repeat("*", len(config.APIKey))
@@ -107,7 +100,7 @@ func createClient(config *ionos.Configuration) (*sdk.APIClient, error) {
 		runtime.GOOS, runtime.GOARCH)
 	sdkConfig.Debug = config.Debug
 
-	return sdk.NewAPIClient(sdkConfig), nil
+	return sdk.NewAPIClient(sdkConfig)
 }
 
 // Records returns the list of resource records in all zones.

--- a/internal/ionoscore/ionoscore_test.go
+++ b/internal/ionoscore/ionoscore_test.go
@@ -33,7 +33,6 @@ func TestNewProvider(t *testing.T) {
 	require.Equal(t, false, p.dryRun)
 	require.Equal(t, false, p.domainFilter.IsConfigured())
 	require.NotNilf(t, p.client, "client should not be nil")
-
 }
 
 func TestRecords(t *testing.T) {

--- a/internal/ionoscore/ionoscore_test.go
+++ b/internal/ionoscore/ionoscore_test.go
@@ -23,17 +23,17 @@ type mockDnsService struct {
 
 func TestNewProvider(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
-	t.Setenv("IONOS_API_KEY", "1")
 
-	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{}, true)
+	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{DryRun: true})
 	require.Equal(t, true, p.dryRun)
 	require.Equal(t, true, p.domainFilter.IsConfigured())
-	require.Equal(t, false, p.domainFilter.Match("b.de."))
+	require.NotNilf(t, p.client, "client should not be nil")
 
-	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{}, false)
+	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{})
 	require.Equal(t, false, p.dryRun)
 	require.Equal(t, false, p.domainFilter.IsConfigured())
-	require.Equal(t, true, p.domainFilter.Match("a.de."))
+	require.NotNilf(t, p.client, "client should not be nil")
+
 }
 
 func TestRecords(t *testing.T) {

--- a/internal/ionoscore/ionoscore_test.go
+++ b/internal/ionoscore/ionoscore_test.go
@@ -25,21 +25,12 @@ func TestNewProvider(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	t.Setenv("IONOS_API_KEY", "1")
 
-	p, err := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{}, true)
-	if err != nil {
-		t.Errorf("should not fail, %s", err)
-	}
-
+	p := NewProvider(endpoint.NewDomainFilter([]string{"a.de."}), &ionos.Configuration{}, true)
 	require.Equal(t, true, p.dryRun)
 	require.Equal(t, true, p.domainFilter.IsConfigured())
 	require.Equal(t, false, p.domainFilter.Match("b.de."))
 
-	p, err = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{}, false)
-
-	if err != nil {
-		t.Errorf("should not fail, %s", err)
-	}
-
+	p = NewProvider(endpoint.DomainFilter{}, &ionos.Configuration{}, false)
 	require.Equal(t, false, p.dryRun)
 	require.Equal(t, false, p.domainFilter.IsConfigured())
 	require.Equal(t, true, p.domainFilter.Match("a.de."))


### PR DESCRIPTION
### Overview and Motivation
According the customer contract IONOS offers 2 public APIs for creating DNS entries:
- for our hosting customers, we offer [IONOS Developer DNS API](https://developer.hosting.ionos.com/docs/dns)
- for our cloud customers, we offer [IONOS cloud DNS API](https://ionos-cloud.github.io/rest-api/docs/dns/v1.ea/)

The ionos plugin automatically uses the correct API based on the given `IONOS_API_KEY`. 

This PR implements the support for the IONOS cloud DNS API. 


### mapping entities

External DNS uses the `endpoint.Endpoint` abstraction for a record in DNS. Normally, a DNS provider must map this abstraction to the entities of the DNS Provider API and vice versa.
In this case for the IONOS cloud DNS API  we have the entities from the [ionos sdk-go-dns](https://github.com/ionos-cloud/sdk-go-dns)
- [Zone ](https://github.com/ionos-cloud/sdk-go-dns/blob/master/model_zone.go)
- [Record](https://github.com/ionos-cloud/sdk-go-dns/blob/master/model_record.go)

Depedant from the use case there are wrapper of the core entities. Concrete you have to implement:

- For the **get records call** ( `GET /records`) : mapping from `[]RecordRead` to `[]*endpoint.Endpoint`. 

- For the  **apply changes call** (`POST /records`) mapping from `[]*endpoint.Endpoint` to `[]RecordRead` ( for deleting records) and mapping `[]*endpoint.Endpoint` to `[]RecordCreate` ( for creating records) 

The interesting thing here is that these are not 1:1 relations. So, 2 `RecordRead` can be "merged" to 1 `endpoint.Endpoint` and vice versa. So the current criteria is when records have the same *name*, *type* and *ttl* they are mapped to one endpoint where the *content*  of the record is a part of `endpoint.Target []string`. 

### handling zones

For finding and creating records you need a zone (id) as an input parameter. As there is no according abstraction on External DNS for zones, we need to derive the zone from the `endpoint.Endpoint.DNSName`.  This is realized with a function for finding a zone for a domainName. The algorithm selects the zone which has the most equal domain parts with the given domain name. In order to minimize the api calls in the *apply changes* use case. We retrieve all zones from the customers at the beginning and the algorithm above operates on these zones which are in memory.

### pagination and limits

The API offers pagination for retrieving zones and records on the customer level. We are using the max page size ( 1000) for the requests and limit the count of items to operate to 10000. 

### filtering

When retrieving zones and records through the API we only load the ones with the "Available" state. This filter is applied on the server side. Filtering names with the [`DomainFilter`](https://github.com/ionos-cloud/external-dns-ionos-webhook/blob/main/pkg/endpoint/domain_filter.go)  ( a feature coming from the External-DNS), is applied on the client side.




