### PR TITLE
fix( external-dns): Use official release image and update the README [DNS-1014]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # ExternalDNS - IONOS Webhook
 
-**⚠️ NOTE**: This Webhook is based on a not yet released version of
-[ExternalDNS](https://github.com/kubernetes-sigs/external-dns) -
-especially the new integration approach by using webhooks, discussed and implemented in
-[PR-3063](https://github.com/kubernetes-sigs/external-dns/pull/3063).
-
 ExternalDNS is a Kubernetes add-on for automatically managing
 Domain Name System (DNS) records for Kubernetes services by using different DNS providers.
 By default, Kubernetes manages DNS records internally,
 but ExternalDNS takes this functionality a step further by delegating the management of DNS records to an external DNS
 provider such as IONOS.
 Therefore, the IONOS webhook allows to manage your
-IONOS domains inside your kubernetes cluster with [ExternalDNS](https://github.com/kubernetes-sigs/external-dns).
+IONOS domains inside your kubernetes cluster with [ExternalDNS](https://github.com/kubernetes-sigs/external-dns). 
 
 To use ExternalDNS with IONOS, you need your IONOS API key or token of the account managing
 your domains.
@@ -35,9 +30,12 @@ kubectl create secret generic ionos-credentials --from-literal=api-key='<EXAMPLE
 # create the helm values file
 cat <<EOF > external-dns-ionos-values.yaml
 image:
-  registry: ghcr.io
-  repository: ionos-cloud/external-dns-webhook-provider
-  tag: latest
+  registry: registry.k8s.io
+  repository: external-dns/external-dns
+  tag: v0.14.0
+
+# restrict to namespace
+# namespace: external-dns 
 
 provider: webhook
 
@@ -46,7 +44,7 @@ extraArgs:
 
 sidecars:
   - name: ionos-webhook
-    image: ghcr.io/ionos-cloud/external-dns-ionos-webhook:$RELEASE_VERSION
+    image: ghcr.io/ionos-cloud/external-dns-ionos-webhook:v0.6.0
     ports:
       - containerPort: 8888
         name: http

--- a/deployments/helm/local-kind-values.yaml
+++ b/deployments/helm/local-kind-values.yaml
@@ -1,7 +1,7 @@
 image:
-  registry: localhost:5001
-  repository: external-dns-webhook-provider
-  tag: latest
+  registry: registry.k8s.io
+  repository: external-dns/external-dns
+  tag: v0.14.0
   pullPolicy: Always
 
 provider: webhook

--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -8,8 +8,6 @@ LOCAL_REGISTRY_NAME=kind-registry
 LOCAL_REGISTRY_RUNNING=$(docker ps -a | grep -q $LOCAL_REGISTRY_NAME && echo "true" || echo "false")
 
 # docker
-IMAGE_EXTERNAL_DNS_WEBHOOK_PROVIDER=ghcr.io/ionos-cloud/external-dns-webhook-provider:latest
-
 IMAGE_REGISTRY=localhost:$LOCAL_REGISTRY_PORT
 IMAGE_NAME=external-dns-ionos-webhook
 IMAGE=$IMAGE_REGISTRY/$IMAGE_NAME
@@ -56,11 +54,6 @@ printf "KIND_CLUSTER_RUNNING: %s\n" "$KIND_CLUSTER_RUNNING"
 if [ "$LOCAL_REGISTRY_RUNNING" = "false" ]; then
     printf "Starting local registry...\n"
     docker run -d --restart=always -p "127.0.0.1:$LOCAL_REGISTRY_PORT:5000" --name "$LOCAL_REGISTRY_NAME" registry:2
-    # once there is an official release of external-dns with the provider webhook, we can remove this steps
-    printf "pushing external-dns-webhook-provider image to local registry...\n"
-    docker pull $IMAGE_EXTERNAL_DNS_WEBHOOK_PROVIDER
-    docker tag $IMAGE_EXTERNAL_DNS_WEBHOOK_PROVIDER localhost:$LOCAL_REGISTRY_PORT/external-dns-webhook-provider:latest
-    docker push localhost:$LOCAL_REGISTRY_PORT/external-dns-webhook-provider:latest
 fi
 
 printf "Building binary...\n"

--- a/test/hurl/service_nodeport.hurl
+++ b/test/hurl/service_nodeport.hurl
@@ -97,7 +97,7 @@ Content-Type: application/json
 
 HTTP/1.1 200
 [Captures]
-node_ip: jsonpath "$.items[0].status.addresses[?(@.type=='InternalIP')].address"
+node_ip: jsonpath "$.items[0].status.addresses[?(@.type=='InternalIP')].address" nth 0
 
 
 # create A record 
@@ -278,9 +278,8 @@ PUT {{dns_mockserver_url}}/mockserver/verify
 Content-Type : application/json
 [Options]
 #very-verbose: true
-retry: true
 retry-interval: 6000
-retry-max-count: 10
+retry: 10
 
 {
     "expectationId": {
@@ -298,9 +297,8 @@ PUT {{dns_mockserver_url}}/mockserver/verify
 Content-Type : application/json
 [Options]
 #very-verbose: true
-retry: true
+retry: 3
 retry-interval: 1000
-retry-max-count: 3
 
 {
     "expectationId": {
@@ -318,9 +316,8 @@ PUT {{dns_mockserver_url}}/mockserver/verify
 Content-Type : application/json
 [Options]
 #very-verbose: trues
-retry: true
+retry: 3
 retry-interval: 1000
-retry-max-count: 3
 
 {
     "expectationId": {
@@ -339,9 +336,8 @@ PUT {{dns_mockserver_url}}/mockserver/verify
 Content-Type : application/json
 [Options]
 #very-verbose: trues
-retry: true
+retry: 3
 retry-interval: 1000
-retry-max-count: 3
 
 {
     "expectationId": {
@@ -360,9 +356,8 @@ PUT {{dns_mockserver_url}}/mockserver/verify
 Content-Type : application/json
 [Options]
 #very-verbose: trues
-retry: true
+retry: 3
 retry-interval: 1000
-retry-max-count: 3
 
 {
     "expectationId": {


### PR DESCRIPTION
As external-dns has now the [webhook feature released ](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.0) , we need to update our project accordingly. I have tested all deployment and acceptance tests changes. 