### PR TITLE
feat: Health and metrics EPs on a separate exposed port [ICNS-1891]

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,28 @@ provider:
         secretKeyRef:
           name: ionos-credentials
           key: api-key
-    - name: SERVER_HOST
-      value: "0.0.0.0"
+    # The webhook server listens on localhost by default. Otherwise, you can set SERVER_HOST.
     - name: SERVER_PORT
+      value: "8888"
+    # The exposed server listens on all interfaces by default. Otherwise, you can set METRICS_HOST.
+    - name: METRICS_PORT
       value: "8080"
     - name: IONOS_DEBUG
       value: "false" # put this to true if you want see details of the http requests
     - name: DRY_RUN
       value: "true" # set to false to apply changes
+    ports:
+      - name: http-health
+        protocol: TCP
+        containerPort: 8080
     livenessProbe:
       httpGet:
         path: /health
+        port: http-health
     readinessProbe:
       httpGet:
         path: /health
+        port: http-health
 EOF
 
 # install external-dns with helm
@@ -182,4 +190,4 @@ scripts/acceptance-tests.sh
 
 ### Metrics
 
-Go runtime metrics are exposed by the `/metrics` endpoint by default at the same port as the server which is 8888. If you are using an old version of the [external dns](https://github.com/kubernetes-sigs/external-dns) chart that expects the metrics to be exposed at a different port, you can set the `METRICS_SERVER` environment variable to `true` and use the `METRICS_PORT` environment variable to set the port. 
+The Go runtime metrics are exposed via the `/metrics` endpoint on port 8080, which is the same port used for exposing the `/health` endpoint.

--- a/cmd/webhook/init/configuration/configuration.go
+++ b/cmd/webhook/init/configuration/configuration.go
@@ -11,8 +11,8 @@ import (
 type Config struct {
 	ServerHost           string        `env:"SERVER_HOST" envDefault:"localhost"`
 	ServerPort           int           `env:"SERVER_PORT" envDefault:"8888"`
+	MetricsHost          string        `env:"METRICS_HOST" envDefault:"0.0.0.0"`
 	MetricsPort          int           `env:"METRICS_PORT" envDefault:"8080"`
-	MetricsServer        bool          `env:"METRICS_SERVER" envDefault:"false"`
 	ServerReadTimeout    time.Duration `env:"SERVER_READ_TIMEOUT"`
 	ServerWriteTimeout   time.Duration `env:"SERVER_WRITE_TIMEOUT"`
 	DomainFilter         []string      `env:"DOMAIN_FILTER" envDefault:""`

--- a/cmd/webhook/init/server/server_test.go
+++ b/cmd/webhook/init/server/server_test.go
@@ -403,7 +403,7 @@ func TestNegotiate(t *testing.T) {
 }
 
 func TestMetricsServer(t *testing.T) {
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/metrics", config.ServerPort), nil)
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%d/metrics", config.MetricsHost, config.MetricsPort), nil)
 	assert.NoError(t, err)
 
 	response, err := http.DefaultClient.Do(request)

--- a/deployments/helm/latest-ionoscore-values.yaml
+++ b/deployments/helm/latest-ionoscore-values.yaml
@@ -19,18 +19,18 @@ sidecars:
     image: ghcr.io/ionos-cloud/external-dns-ionos-webhook:latest
     imagePullPolicy: Always
     ports:
-      - containerPort: 8888
-        name: http
+      - containerPort: 8080
+        name: http-health
     livenessProbe:
       httpGet:
         path: /health
-        port: http
+        port: http-health
       initialDelaySeconds: 10
       timeoutSeconds: 5
     readinessProbe:
       httpGet:
         path: /health
-        port: http
+        port: http-health
       initialDelaySeconds: 10
       timeoutSeconds: 5
     env:
@@ -48,8 +48,6 @@ sidecars:
 #        value: ""
 #      - name: REGEXP_DOMAIN_FILTER_EXCLUSION
 #        value: ""
-      - name: SERVER_HOST
-        value: "0.0.0.0"
       - name: IONOS_API_KEY
         value: "put your api key here"
       - name: IONOS_DEBUG

--- a/deployments/helm/local-kind-values.yaml
+++ b/deployments/helm/local-kind-values.yaml
@@ -19,18 +19,18 @@ sidecars:
     image: localhost:5001/external-dns-ionos-webhook:latest
     imagePullPolicy: Always
     ports:
-      - containerPort: 8888
-        name: http
+      - containerPort: 8080
+        name: http-health
     livenessProbe:
       httpGet:
         path: /health
-        port: http
+        port: http-health
       initialDelaySeconds: 10
       timeoutSeconds: 5
     readinessProbe:
       httpGet:
         path: /health
-        port: http
+        port: http-health
       initialDelaySeconds: 10
       timeoutSeconds: 5
     env:
@@ -48,8 +48,6 @@ sidecars:
 #        value: ""
 #      - name: REGEXP_DOMAIN_FILTER_EXCLUSION
 #        value: ""
-      - name: SERVER_HOST
-        value: "0.0.0.0"
       - name: IONOS_API_KEY
         value: "test-api-key"
       - name: IONOS_API_URL

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -20,7 +20,6 @@ const (
 	acceptHeader           = "Accept"
 	varyHeader             = "Vary"
 	supportedMediaVersions = "1"
-	healthPath             = "/health"
 	logFieldRequestPath    = "requestPath"
 	logFieldRequestMethod  = "requestMethod"
 	logFieldError          = "error"
@@ -69,16 +68,6 @@ type Webhook struct {
 func New(provider provider.Provider) *Webhook {
 	p := Webhook{provider: provider}
 	return &p
-}
-
-func Health(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == healthPath {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 func (p *Webhook) contentTypeHeaderCheck(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
## Changes:

- `/metrics` and `/health` EPs are now served always on the same port 8080 on host 0.0.0.0 by default