### PR TITLE
chore(server): Changed /health EP path to /healthz [ICNS-1891]

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ provider:
       protocol: TCP
     livenessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
     readinessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
 EOF
 
@@ -192,4 +192,4 @@ scripts/acceptance-tests.sh
 
 ### Metrics
 
-The Go runtime metrics are exposed via the `/metrics` endpoint on port 8080, which is the same port used for exposing the `/health` endpoint.
+The Go runtime metrics are exposed via the `/metrics` endpoint on port 8080, which is the same port used for exposing the `/healthz` endpoint.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ provider:
   webhook:
     image:
       repository: ghcr.io/ionos-cloud/external-dns-ionos-webhook
-      tag: v0.6.3
+      tag: v0.7.0
       pullPolicy: IfNotPresent
     env:
     - name: LOG_LEVEL

--- a/cmd/webhook/init/server/server.go
+++ b/cmd/webhook/init/server/server.go
@@ -39,10 +39,8 @@ func Init(config configuration.Config, p *webhook.Webhook) *http.Server {
 		}
 	}()
 
-	// Minor note: (Emilija) According to docs, the liveness probe EP should be "/healthz"
-	// https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/webhook-provider/#exposed-endpoints
 	rExposed := chi.NewRouter()
-	rExposed.Get("/health", healthCheckHandler)
+	rExposed.Get("/healthz", healthCheckHandler)
 	rExposed.Get("/metrics", promhttp.Handler().ServeHTTP)
 
 	srvExposed := createHTTPServer(fmt.Sprintf("%s:%d", config.MetricsHost, config.MetricsPort), rExposed, config.ServerReadTimeout, config.ServerWriteTimeout)

--- a/deployments/helm/latest-ionoscore-values.yaml
+++ b/deployments/helm/latest-ionoscore-values.yaml
@@ -28,13 +28,13 @@ provider:
         protocol: TCP
     livenessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
       initialDelaySeconds: 10
       timeoutSeconds: 5
     readinessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
       initialDelaySeconds: 10
       timeoutSeconds: 5

--- a/deployments/helm/latest-ionoscore-values.yaml
+++ b/deployments/helm/latest-ionoscore-values.yaml
@@ -15,7 +15,7 @@ provider:
   webhook:
     image:
       repository: ghcr.io/ionos-cloud/external-dns-ionos-webhook
-      tag: v0.6.3
+      tag: v0.7.0
       pullPolicy: Always
     ports:
       - containerPort: 8888

--- a/deployments/helm/local-kind-values.yaml
+++ b/deployments/helm/local-kind-values.yaml
@@ -28,13 +28,13 @@ provider:
         protocol: TCP
     livenessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
       initialDelaySeconds: 10
       timeoutSeconds: 5
     readinessProbe:
       httpGet:
-        path: /health
+        path: /healthz
         port: 8080
       initialDelaySeconds: 10
       timeoutSeconds: 5


### PR DESCRIPTION
## Changes:

- Upgraded the version of image for our webhook provider in helm chart values to latest one ([v0.7.0](https://github.com/ionos-cloud/external-dns-ionos-webhook/pkgs/container/external-dns-ionos-webhook/366336342?tag=v0.7.0))