### PR TITLE
chore(docs): Use default values for ports, liveliness and readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ rbac:
   create: false
 ```
 
-
 See [here](./cmd/webhook/init/configuration/configuration.go) for all available configuration options of the IONOS webhook.
 
 ## Verify the image resource integrity
@@ -110,6 +109,10 @@ by [sigstores transparency log](https://github.com/sigstore/rekor).
 export RELEASE_VERSION=latest
 cosign verify --insecure-ignore-tlog --key cosign.pub ghcr.io/ionos-cloud/external-dns-ionos-webhook:$RELEASE_VERSION
 ```
+
+### Metrics
+
+The Go runtime metrics are exposed via the `/metrics` endpoint, and the health check is available on the `/healthz` endpoint. Both endpoints are served on port 8080 by default.
 
 ## Development
 
@@ -173,6 +176,3 @@ To view the test reports, see the `./build/reports/hurl` directory.
 scripts/acceptance-tests.sh 
 ```
 
-### Metrics
-
-The Go runtime metrics are exposed via the `/metrics` endpoint on port 8080, which is the same port used for exposing the `/healthz` endpoint.

--- a/README.md
+++ b/README.md
@@ -70,23 +70,6 @@ provider:
       value: "false" # change to "true" if you want see details of the http requests
     - name: DRY_RUN
       value: "true" # set to "false" when you want to allow making changes to your DNS resources
-    ports:
-    - containerPort: 8888
-      name: http-webhook
-      hostPort: 8888
-      protocol: TCP
-    - containerPort: 8080
-      name: http-health
-      hostPort: 8080
-      protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
-    readinessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
 EOF
 
 # install external-dns with helm

--- a/deployments/helm/latest-ionoscore-values.yaml
+++ b/deployments/helm/latest-ionoscore-values.yaml
@@ -17,27 +17,6 @@ provider:
       repository: ghcr.io/ionos-cloud/external-dns-ionos-webhook
       tag: v0.8.0
       pullPolicy: Always
-    ports:
-      - containerPort: 8888
-        name: http-webhook
-        hostPort: 8888
-        protocol: TCP
-      - containerPort: 8080
-        hostPort: 8080
-        name: http-health-metrics
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
-    readinessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
     env:
       - name: LOG_LEVEL
         value: debug

--- a/deployments/helm/local-kind-values.yaml
+++ b/deployments/helm/local-kind-values.yaml
@@ -17,27 +17,6 @@ provider:
       repository: localhost:5001/external-dns-ionos-webhook
       tag: latest
       pullPolicy: Always
-    ports:
-      - containerPort: 8888                                                                                                                                                    │
-        name: http-webhook
-        hostPort: 8888
-        protocol: TCP
-      - containerPort: 8080
-        hostPort: 8080
-        name: http-health-metrics
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
-    readinessProbe:
-      httpGet:
-        path: /healthz
-        port: 8080
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
     env:
       - name: LOG_LEVEL
         value: debug


### PR DESCRIPTION
## Changes: 

- Changed the README.md - removed the values for ports, liveliness and readiness probe. 
- Changed the values yaml files we have for testing locally and the one with the latest values