### PR TITLE
fix(ci): use the same go version as go.mod

### DIFF
--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
-
+          go-version-file: 'go.mod'
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: Run Unit Tests
         run: make unit-test
       - name: Test Report


### PR DESCRIPTION
Background: by using `go-version: stable`, the `setup-go` actions installs the latest stable go version which may not necessarily be compatible with our project. Currenly, the action installs `1.25.0` go version which causes the ci to fail, to some incompatible librairies. 